### PR TITLE
style google acount and company logo for gsuite in mail

### DIFF
--- a/gmail.user.css
+++ b/gmail.user.css
@@ -1093,7 +1093,8 @@
     .byl .nZ.aS6 {
         background-color: #31363f;
     }
-    .gb_0 {
+    .gb_0,
+    .gb_ja.gb_wg.gb_i {
         background: #232323;
         border: 1px solid #232323;
     }
@@ -1822,7 +1823,7 @@
     .NQ .afM {
         filter: invert(1);
     }
-    
+
     /* Support and updates */
     .hcfe {
         background-color: #232323;


### PR DESCRIPTION
I checked that this doesn't interfere with a normal free account in mail.

It looked like this before (with pixelated company and account image):
![before](https://user-images.githubusercontent.com/1125067/109312667-386ef280-783f-11eb-93fb-980835b1bf62.png)

And this is what it looks like with my change applied:
![after](https://user-images.githubusercontent.com/1125067/109312708-43298780-783f-11eb-8690-dacceaedf7d4.png)
