### PR TITLE
make calendar icon in mail list visible

### DIFF
--- a/gmail.user.css
+++ b/gmail.user.css
@@ -874,7 +874,7 @@
         background-color: #2b2b2b;
         color: #e3e3e3;
     }
-    .yE {
+    .yE, .xL {
         filter: invert(100%);
     }
 


### PR DESCRIPTION
This is in Gmail in the main mail view when an email contains a calendar invite.

Before:
![before](https://user-images.githubusercontent.com/1125067/109325585-0022e080-784e-11eb-8669-65fd45988119.png)

After:
![after](https://user-images.githubusercontent.com/1125067/109325574-fbf6c300-784d-11eb-8007-a6b5dcfac6cb.png)
