### PR TITLE
style warning box for recipient outside org

### DIFF
--- a/gmail.user.css
+++ b/gmail.user.css
@@ -1793,6 +1793,12 @@
     .gb_Ue {
         background: #1f1f1f;
     }
+    .a8i.bii {
+        background-color: #1b1b1b;
+    }
+    .a8i.bii td.bfJ div.bo {
+        filter: invert(1);
+    }
 }
 
 @-moz-document url-prefix("https://mail.google.com/mail/"), url-prefix("https://www.google.com/tools/feedback/") {


### PR DESCRIPTION
This box shows up when you're in a GSuite account and you email someone outside of your organisation as well as people inside it.

Before:
![before](https://user-images.githubusercontent.com/1125067/111649378-3a075700-87fc-11eb-9532-946015da2999.png)

After:
![after](https://user-images.githubusercontent.com/1125067/111649408-4095ce80-87fc-11eb-998f-c87c4d567e34.png)

I picked the same colour that you've used for the original colour in other contexts. 