### PR TITLE
remove white box under inline respond in column inbox view

### DIFF
--- a/gmail.user.css
+++ b/gmail.user.css
@@ -1793,6 +1793,9 @@
     .gb_Ue {
         background: #1f1f1f;
     }
+    .aC2 {
+        background: inherit;
+    }
 }
 
 @-moz-document url-prefix("https://mail.google.com/mail/"), url-prefix("https://www.google.com/tools/feedback/") {


### PR DESCRIPTION
This only happens when you're in column inbox view, and you respond inline, and scroll all the way down. Easy to miss.

Before:
![image](https://user-images.githubusercontent.com/1125067/111825881-ea9a5700-88df-11eb-949c-ca14ee613293.png)

After:
![image](https://user-images.githubusercontent.com/1125067/111825897-ee2dde00-88df-11eb-94d2-2560b08b6db4.png)
