### PR TITLE
style "resend email" notification bar

### DIFF
--- a/gmail.user.css
+++ b/gmail.user.css
@@ -1057,6 +1057,9 @@
     .nH .ya .x8 {
         color: #54a3e9;
     }
+    .nH .bAR {
+        background-color: inherit;
+    }
     .gb_me.gb_ve .gb_je .gb_if {
         border-color: #232323;
         background: #2d2d2d;


### PR DESCRIPTION
This is on the right hand side in split view when you select an email that has a follow-up/resend reminder. Not sure if non GSuite does this.

Before:
![image](https://user-images.githubusercontent.com/1125067/112288191-00fc3600-8c85-11eb-8d75-ae8e9d5b3e1e.png)

After:
![image](https://user-images.githubusercontent.com/1125067/112288204-03f72680-8c85-11eb-8094-61e217b2457a.png)

Background is the same as the rest of that section, so I kept it like that.

Please note I'm not bumping the version number when I send these PRs. Thanks.