### PR TITLE
Update gmail.user.css

### DIFF
--- a/gmail.user.css
+++ b/gmail.user.css
@@ -10,7 +10,7 @@
 @var checkbox highlight_unread 'Stronger Highlight | Unread Messages' 0
 ==/UserStyle== */
 @-moz-document url-prefix("https://mail.google.com/mail/") {
-    .aic, .aeN .ajl, .G-atb::before, .aAA.J-KU-Jg-K9, .l2, .bkK, .aeJ, .iY .Bu, .wR > .amn, .SI .aBz, .iC, .gb_oe.gb_la.gb_pe, #aso_search_form_anchor.gb_Ee.gb_df.gb_Fe, .bAw, .if, .UG, .aeN, .qd {
+    .aic, .aeN .ajl, .G-atb::before, .aAA.J-KU-Jg-K9, .l2, .bkK, .aeJ, .iY .Bu, .wR > .amn, .SI .aBz, .iC, .gb_oe.gb_la.gb_pe, #aso_search_form_anchor, .bAw, .if, .UG, .aeN, .qd {
         background: #1f1f1f !important;
     }
     .V6.CL {


### PR DESCRIPTION
Updated as with the existing method, the search bar was white until you click into it.